### PR TITLE
include utility because using std::move

### DIFF
--- a/anything_but/dbj_nothing_but.h
+++ b/anything_but/dbj_nothing_but.h
@@ -18,6 +18,7 @@
 */
 
 #include <type_traits>
+#include <utility>
 
 // firmware, drivers, avionics and simillar projects 
 // very likely do not use C++ streams


### PR DESCRIPTION
Should `#include <utility>` (because of std::move) to be self-contained.